### PR TITLE
Conditionally decrypt PDFs with qpdf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.9-slim
 LABEL maintainer "DataMade <info@datamade.us>"
 
 RUN apt-get update && \
-    apt-get install -y make libreoffice poppler-utils wget && \
+    apt-get install -y make libreoffice poppler-utils qpdf wget && \
     rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /app


### PR DESCRIPTION
## Description

Per the recommendation in [this thread](https://stackoverflow.com/a/68900681), this PR adds conditional decryption to PDF attachments using pdfinfo and qpdf.

### Testing instructions

- Check out this branch
- Build image from the updated Dockerfile: `docker-compose build merger`
- Run this command and verify a merged PDF is built: `docker-compose run --rm -e attachment_links='["https://metro.legistar1.com/metro/meetings/2021/7/2086_A_Finance%2C_Budget_and_Audit_Committee_21-07-14_Agenda.pdf", "https://metro.legistar.com/ViewReport.ashx?M=R&N=TextL5&GID=557&ID=7812&GUID=LATEST&Title=Board+Report", "http://metro.legistar1.com/metro/attachments/48c87bb8-4129-460a-a2fa-b7e84957045e.pdf", "http://metro.legistar1.com/metro/attachments/19f89300-ac83-4ea3-bdde-f465eb8e4196.pdf"]' merger make merged/finance-budget-and-audit-committee-0438e80771e6.pdf`
  - `48c87bb8-4129-460a-a2fa-b7e84957045e.pdf` is an encrypted PDF, see #2

Handles #2